### PR TITLE
Add credits property

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -88,16 +88,16 @@ jobs:
       - name: Install using pip
         run: pip3 install .
 
-      #- name: Try example in /tmp
-      #env:
-      #SMSBOX_API_KEY: ${{ secrets.SMSBOX_API_KEY }}
-      #run: |
-      #mkdir -p /tmp/test_example
-      #cp example.py /tmp/test_example
-      #cd /tmp/test_example
-      #python3 /tmp/test_example/example.py
-      #cd -
-      #rm -rf /tmp/test_example
+      - name: Try example in /tmp
+        env:
+          SMSBOX_API_KEY: ${{ secrets.SMSBOX_API_KEY }}
+        run: |
+          mkdir -p /tmp/test_example
+          cp example.py /tmp/test_example
+          cd /tmp/test_example
+          python3 /tmp/test_example/example.py
+          cd -
+          rm -rf /tmp/test_example
 
   test_build:
     name: Test building  with Python 3

--- a/example.py
+++ b/example.py
@@ -13,12 +13,17 @@ async def main():
         sms = Client(session, "https://api.smsbox.pro", API_KEY)
 
         try:
-            msgID = await sms.send(
-                SMS_RECIPIENT, "Test message.", "expert", {"strategy": "2", "id": "1"}
-            )
-            print(f"SMS sent, ID : {msgID}")
+            # msgID = await sms.send(
+            #     SMS_RECIPIENT, "Test message.", "expert", {"strategy": "2", "id": "1"}
+            # )
+            # print(f"SMS sent, ID : {msgID}")
+            credits = await sms.credits
+            if credits > 0:
+                print("There are remaining credits")
+            else:
+                print("No remaining credit")
         except exceptions.SMSBoxException as e:
-            print(f"As expected, exception: {e}")
+            print(f"Exception: {e}")
             await session.close()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
 ]
 dependencies = [
     "aiohttp>=3.8.0,<4.0",
+    "async-property==0.2.1",
 ]
 
 [project.urls]

--- a/pysmsboxnet/api.py
+++ b/pysmsboxnet/api.py
@@ -4,6 +4,7 @@ import asyncio
 
 from aiohttp import ClientSession
 from aiohttp.client import ClientTimeout
+from async_property import async_property
 
 from . import exceptions
 
@@ -71,3 +72,16 @@ class Client:
             if len(respOK) == 1:
                 return "0"
             return respOK[1]
+
+    @async_property
+    async def credits(self):
+        """Return number of credits."""
+        postData = {
+            "action": "credit",
+        }
+
+        respText = await self.__smsbox_request("api.php", postData)
+        if respText.startswith("CREDIT"):
+            return respText.split(" ")[1]
+        else:
+            raise exceptions.SMSBoxException(respText)

--- a/pysmsboxnet/api.py
+++ b/pysmsboxnet/api.py
@@ -82,6 +82,6 @@ class Client:
 
         respText = await self.__smsbox_request("api.php", postData)
         if respText.startswith("CREDIT"):
-            return respText.split(" ")[1]
+            return float(respText.split(" ")[1])
         else:
             raise exceptions.SMSBoxException(respText)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiohttp>=3.8.0,<4.0
 aresponses==2.1.6
+async-property==0.2.1
 black==22.10.0
 codespell==v2.1.0
 coverage==6.5.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -265,3 +265,28 @@ async def test_ok_with_id(aresponses):
         )
         assert MSG_ID == result
         await session.close()
+
+
+@pytest.mark.asyncio
+async def test_credits(aresponses):
+    """Test credits async property returning a random number."""
+    # Get a random float which will serv as the number of credits
+    CREDITS = str(round(random.uniform(0, 9999), 1))
+    aresponses.add(
+        "api.smsbox.pro",
+        "/api.php",
+        "post",
+        aresponses.Response(
+            text=f"CREDIT {CREDITS}",
+            status=200,
+        ),
+    )
+    async with aiohttp.ClientSession() as session:
+        sms = Client(
+            session,
+            SMSBOX_HOST,
+            SMSBOX_API_KEY,
+        )
+        result = await sms.credits
+        assert CREDITS == result
+        await session.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -271,7 +271,7 @@ async def test_ok_with_id(aresponses):
 async def test_credits(aresponses):
     """Test credits async property returning a random number."""
     # Get a random float which will serv as the number of credits
-    CREDITS = str(round(random.uniform(0, 9999), 1))
+    CREDITS = round(random.uniform(0, 9999), 1)
     aresponses.add(
         "api.smsbox.pro",
         "/api.php",


### PR DESCRIPTION
- Add async-property to requirements
- Add credits async property to return available credits on the account
- Add test
- Credits is float not str
- Get credits instead of sending a message in the example
- Re-enable example.py in GH actions
