### PR TITLE
Add returned types in function definitions

### DIFF
--- a/pysmsboxnet/api.py
+++ b/pysmsboxnet/api.py
@@ -18,7 +18,7 @@ class Client:
         self.session = session
         self.timeout = timeout
 
-    async def __smsbox_request(self, uri: str, parameters: dict):
+    async def __smsbox_request(self, uri: str, parameters: dict) -> str:
         """Send a request to the API."""
         headers = {
             "authorization": f"App {self.cleApi}",
@@ -54,7 +54,7 @@ class Client:
                 f"reached while sending the SMS"
             ) from exception
 
-    async def send(self, dest: str, msg: str, mode: str, parameters: dict):
+    async def send(self, dest: str, msg: str, mode: str, parameters: dict) -> int:
         """Send a SMS."""
         postData = {
             "dest": dest,
@@ -69,5 +69,5 @@ class Client:
         if respText.startswith("OK"):
             respOK = respText.split(" ")
             if len(respOK) == 1:
-                return "0"
-            return respOK[1]
+                return 0
+            return int(respOK[1])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -233,7 +233,7 @@ async def test_ok(aresponses):
             SEND_MODE,
             {"strategy": SMSBOX_STRATEGY},
         )
-        assert "0" == result
+        assert 0 == result
         await session.close()
 
 
@@ -241,7 +241,7 @@ async def test_ok(aresponses):
 async def test_ok_with_id(aresponses):
     """Test result OK with a random ID."""
     # Get a random integer which will serv as the message ID
-    MSG_ID = str(random.randint(100000000000, 999999999999))
+    MSG_ID = random.randint(100000000000, 999999999999)
     aresponses.add(
         "api.smsbox.pro",
         "/1.1/api.php",


### PR DESCRIPTION
Specify __smsbox_request returns a str and modify send to return an int because SMSBox API returns an integer number for the message ID.
