### PR TITLE
Force HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The `pysmsboxnet.net.api.Client` has the following methods:
 
 - Constructor which takes the following arguments:
   - session: an instance of aiohttp.ClientSession
-  - host (str): the SMSBox API endpoint I.E. `https://api.smsbox.pro`
+  - host (str): the SMSBox API endpoint I.E. `api.smsbox.pro` (without http(s):// because https is forced)
   - cleApi (str): your smsbox.net API key, [see API documentation](https://en.smsbox.net/docs/doc-API-SMSBOX-1.1-EN.html); name is in French to reflect API documentation
   - timeout (int, optional, default 30
 - Send (return int: 0 or ID of sent SMS if applicable)

--- a/example.py
+++ b/example.py
@@ -10,7 +10,7 @@ from pysmsboxnet.api import Client
 
 async def main():
     async with aiohttp.ClientSession() as session:
-        sms = Client(session, "https://api.smsbox.pro", API_KEY)
+        sms = Client(session, "api.smsbox.pro", API_KEY)
 
         try:
             # To send a message

--- a/pysmsboxnet/api.py
+++ b/pysmsboxnet/api.py
@@ -27,7 +27,7 @@ class Client:
 
         try:
             async with self.session.post(
-                url=f"{self.host}/{uri}",
+                url=f"https://{self.host}/{uri}",
                 headers=headers,
                 data=parameters,
                 timeout=ClientTimeout(total=self.timeout),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,7 @@ from pysmsboxnet import exceptions
 from pysmsboxnet.api import Client
 
 # Constents
-SMSBOX_HOST = "https://api.smsbox.pro"
+SMSBOX_HOST = "api.smsbox.pro"
 SMSBOX_API_KEY = "pub-xxxxx-xxxxx-xxxx-xxxx-xxxxx-xxxxxxxx"
 SMS_RECIPIENT = "9999001"
 SMS_MSG = "Test d'un message ! En plus il va être envoyé."


### PR DESCRIPTION
From december 1st 2022, the API endpoints won't be usable anymore using HTTP.
The host property now only have to be set with the endpoint, for example api.smsbox.pro instead of https://api.smsbox.pro
