### PR TITLE
Deploy documentation only when py files or doc itself is modified

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,6 +13,20 @@ permissions:
   contents: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docfiles: ${{ steps.filter.outputs.docfiles }}
+    steps:
+      - uses: actions/checkout@v3.2.0
+      - uses: dorny/paths-filter@v2.11.1
+        id: filter
+        with:
+          filters: |
+            docfiles:
+              - 'pysmsboxnet/*.py'
+              - 'docs/**'
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -124,8 +138,8 @@ jobs:
         run: python3 -m build
 
   deploy_doc:
-    if: github.event_name == 'push'
-    needs: test_build
+    if: github.event_name == 'push' && needs.changes.outputs.docfiles == 'true'
+    needs: [test_build, changes]
     runs-on: ubuntu-latest
     name: Build and deploydocumentation from main
     steps:


### PR DESCRIPTION
It is not needed to deploy documentation if only GitHub actions files are modified.
