### PR TITLE
Fix version for Codecov action

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: upload to codecov
         if: ${{ matrix.python-version == '3.10' }}
-        uses: codecov/codecov-action@3.1.2
+        uses: codecov/codecov-action@v3.1.2
 
   test_install:
     name: Test installing  with Python ${{ matrix.python-version }}


### PR DESCRIPTION
Dependabot missed the `v` to prefix the version and I did not notice this.
