### PR TITLE
Bump Python to 3.11 instead of 3.x for lint and docs workflows

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-python@v4.7.1
         id: python
         with:
-          python-version: 3.x
+          python-version: 3.11
           cache: pip
           cache-dependency-path: |
             **/requirements*.txt
@@ -177,7 +177,7 @@ jobs:
         uses: actions/setup-python@v4.7.1
         id: python
         with:
-          python-version: "3.x"
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: |
             **/requirements*.txt


### PR DESCRIPTION
Signed-off-by: Patrick ZAJDA <patrick@zajda.fr>
