### PR TITLE
Switch to setuptools-scm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Ignore version file
+src/pysmsboxnet/_version.py

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,4 @@ comment: # this is a top-level key
   require_changes: true
 ignore:
   - "src/pysmsboxnet/_version.py"
+  - "src/pysmsboxnet/__init__.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,4 @@
 comment: # this is a top-level key
   require_changes: true
+ignore:
+  - "src/pysmsboxnet/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ include-package-data = false
 [tool.black]
 target-version = ["py39", "py310"]
 exclude = 'generated'
+extend-exclude = 'src/pysmsboxnet/_version.py'
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = [ "setuptools", "setuptools-git-versioning", ]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -52,5 +52,5 @@ exclude = 'generated'
 [tool.isort]
 profile = "black"
 
-[tool.setuptools-git-versioning]
-enabled = true
+[tool.setuptools_scm]
+version_file = "src/pysmsboxnet/_version.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
+exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build,src/pysmsboxnet/_version.py
 max-complexity = 25
 doctests = True
 # To work with Black

--- a/src/pysmsboxnet/__init__.py
+++ b/src/pysmsboxnet/__init__.py
@@ -1,1 +1,7 @@
 """Python library to use smsbox.net API."""
+try:
+    from ._version import version as __version__  # type: ignore
+    from ._version import version_tuple  # type: ignore
+except ImportError:
+    __version__ = "unknown version"
+    version_tuple = (0, 0, "unknown version")


### PR DESCRIPTION
I plan to suggest to add to Debian by contributing a package.
It is now compromised because setuptools-git-versioning is not part of Debian but setuptools-scm is already packaged.
