### PR TITLE
Replace all possible linters by Ruff

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -46,12 +46,9 @@ jobs:
         run: |
           python3 -m venv venv
           source venv/bin/activate
+          pip3 install --upgrade pip
           pip3 install -e ".[lint]"
 
-      - name: 🖤 Lint with Black
-        run: venv/bin/black src tests --check
-      - name: 🖤 Lint with Ruff
-        run: venv/bin/ruff check
       - name: Pre-commit cache
         uses: actions/cache@v4.0.0
         with:
@@ -60,7 +57,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pre-commit-
 
-      - name: "Run pre-commits"
+      - name: "🖤  Run pre-commits"
         run: venv/bin/pre-commit run --all-files
 
   test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,12 @@
 ---
 repos:
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        name: isort (python)
-  - repo: https://github.com/psf/black
-    rev: 24.1.0
-    hooks:
-      - id: black
-        args:
-          - --safe
-          - --quiet
-        #files: ^((pysmsboxnet|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
+      - id: check-toml
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
-    hooks:
-      - id: pyupgrade
-        args: [--py39-plus]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/example.py
+++ b/example.py
@@ -5,7 +5,6 @@ from os import getenv
 from sys import exit
 
 import aiohttp
-
 from pysmsboxnet import exceptions
 from pysmsboxnet.api import Client
 
@@ -22,7 +21,7 @@ async def main():
             # With the parameter id set to 1
             # If we don't set id, the send function will return 0
             # In case of failure an exception will be thrown
-            # It is commented, delete the # character and the following space on each line to uncomment it
+            # Uncomment it if you need it
             # msgID = await sms.send(
             #     SMS_RECIPIENT, "Test message.", "expert", {"strategy": "2", "id": "1"}
             # )
@@ -30,9 +29,9 @@ async def main():
             # print(f"SMS sent, ID : {msgID}")
 
             # We get remaining credits
-            credits = await sms.get_credits()
-            # print(f"Remaining credits: {credits}")
-            if credits > 0:
+            remaining_credits = await sms.get_credits()
+            # print(f"Remaining credits: {remaining_credits}")
+            if remaining_credits > 0:
                 print("There are remaining credits")
             else:
                 print("No remaining credit")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,6 @@ doc = [
     "furo==2023.9.10",
 ]
 lint = [
-    "black==24.1.0",
-    "codespell==v2.2.6",
-    "ruff==0.1.14",
-    "isort==5.13.2",
     "mypy==1.8.0",
     "pre-commit==3.6.0",
 ]
@@ -66,19 +62,11 @@ test = [
 platforms = ["any"]
 include-package-data = false
 
-[tool.black]
-target-version = ["py39", "py310"]
-exclude = 'generated'
-extend-exclude = 'src/pysmsboxnet/_version.py'
-
-[tool.isort]
-profile = "black"
-
 [tool.setuptools_scm]
 version_file = "src/pysmsboxnet/_version.py"
 
 [tool.ruff]
-exclude = [
+extend-exclude = [
     ".venv",
     ".git",
     ".tox",
@@ -91,16 +79,29 @@ exclude = [
     "src/pysmsboxnet/_version.py",
 ]
 ignore = [
-    "D202",
     "D203",
     "D213",
     "E501",
 ]
-select = [
+extend-select = [
+    "A",
+    "ASYNC",
+    "B",
+    "C",
+    "C416",
     "C9",
     "D",
     "E",
     "F",
+    "I",
+    "N",
+    "PL",
+    "PLC",
+    "PLE",
+    "PLR",
+    "PLW",
+    "RUF",
+    "UP",
     "W",
 ]
 

--- a/src/pysmsboxnet/exceptions.py
+++ b/src/pysmsboxnet/exceptions.py
@@ -58,6 +58,6 @@ class InternalErrorException(SMSBoxException):
 class HTTPException(SMSBoxException):
     """Exception when API returns ERROR 03."""
 
-    def __init__(self, errorCode: int):
+    def __init__(self, error_code: int):
         """Initialize HTTP error Exception."""
-        super().__init__(f"HTTP error ({errorCode})")
+        super().__init__(f"HTTP error ({error_code})")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,7 +7,6 @@ from typing import Any
 
 import aiohttp
 import pytest
-
 from pysmsboxnet import exceptions
 from pysmsboxnet.api import Client
 
@@ -244,13 +243,13 @@ async def test_ok(aresponses: Any) -> None:
 async def test_ok_with_id(aresponses: Any) -> None:
     """Test result OK with a random ID."""
     # Get a random integer which will serv as the message ID
-    MSG_ID = random.randint(100000000000, 999999999999)
+    msg_id = random.randint(100000000000, 999999999999)
     aresponses.add(
         "api.smsbox.pro",
         "/1.1/api.php",
         "post",
         aresponses.Response(
-            text=f"OK {MSG_ID}",
+            text=f"OK {msg_id}",
             status=200,
         ),
     )
@@ -266,7 +265,7 @@ async def test_ok_with_id(aresponses: Any) -> None:
             SEND_MODE,
             {"strategy": SMSBOX_STRATEGY, "id": "1"},
         )
-        assert MSG_ID == result
+        assert msg_id == result
         await session.close()
 
 
@@ -274,13 +273,13 @@ async def test_ok_with_id(aresponses: Any) -> None:
 async def test_credits(aresponses: Any) -> None:
     """Test credits async property returning a random number."""
     # Get a random float which will serv as the number of credits
-    CREDITS = round(random.uniform(0, 9999), 1)
+    account_credits = round(random.uniform(0, 9999), 1)
     aresponses.add(
         "api.smsbox.pro",
         "/api.php",
         "post",
         aresponses.Response(
-            text=f"CREDIT {CREDITS}",
+            text=f"CREDIT {account_credits}",
             status=200,
         ),
     )
@@ -291,7 +290,7 @@ async def test_credits(aresponses: Any) -> None:
             SMSBOX_API_KEY,
         )
         result = await sms.get_credits()
-        assert CREDITS == result
+        assert account_credits == result
         await session.close()
 
 


### PR DESCRIPTION
Remove all linters from pyproject.toml in requirements, only use pre-commit to execute linters.
Also add check-toml pre-commit hook.
Every Python files are checked, also example and script directory.
Variables are now all lowercase, which makes a breaking change for `cleApi` which is now `cle_api`.
