### PR TITLE
Remove pip cache from setup python when deploying documentation

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -185,8 +185,6 @@ jobs:
         id: python
         with:
           python-version: "3.11"
-          cache: pip
-          cache-dependency-path: pyproject.toml
           check-latest: true
 
       - name: Create and activate a virtual environment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,6 @@ jobs:
         id: python
         with:
           python-version: "3.10"
-          cache: pip
-          cache-dependency-path: pyproject.toml
           check-latest: true
 
       - name: Create and activate a virtual environment


### PR DESCRIPTION
Uv is used so no need to cache pip anymore.
