### PR TITLE
run setuptools_scm command line with uv run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:line-length
 name: Release
 
 on:
@@ -72,14 +73,12 @@ jobs:
         id: python
 
       - name: 📦 Install dependencies
-        run: |
-          uv sync --frozen --extra doc
-          uv pip install  "setuptools_scm>=8"
+        run: uv sync --frozen --extra doc
 
       - name: Get version
         id: get-version
         run: |
-          echo "VERSION=$(python3 -m setuptools_scm)" >> $GITHUB_OUTPUT
+          echo "VERSION=$(uv run --no-project --isolated --with "setuptools_scm>=8" python3 -m setuptools_scm)" >> $GITHUB_OUTPUT
 
       - name: Build documentation using sphinx
         run: uv run make -C docs html


### PR DESCRIPTION
Using uv pip install in the virtual environment is not a clean solution.
