### PR TITLE
Skip uv-lock for pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,4 +46,6 @@ repos:
         require_serial: true
         files: ^(src/pysmsboxnet)/.+\.py$
 ci:
-  skip: ["mypy"]
+  skip:
+    - "mypy"
+    - "uv-lock"


### PR DESCRIPTION
Pre-commit.ci makes a timeout error when running uv-lock.
