### PR TITLE
Refresh uv.lock with uv 0.5.19 to remove dynamic version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.5.18
+    rev: 0.5.20
     hooks:
       - id: uv-lock
   - repo: https://github.com/renovatebot/pre-commit-hooks

--- a/uv.lock
+++ b/uv.lock
@@ -836,7 +836,6 @@ wheels = [
 
 [[package]]
 name = "pysmsboxnet"
-version = "2024.6.2.dev215+g852816e"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
- **Update uv pre-commit hook**
- **Refresh uv.lock**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated pre-commit configuration to use the latest version of `uv-pre-commit`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->