### PR TITLE
uv.lock: set uv minimum version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ exclude = [
     ".pre-commit-config.yaml "
 ]
 
+[tool.uv]
+required-version = ">=0.5.19"
+
 [tool.ruff]
 extend-exclude = [
     ".venv",


### PR DESCRIPTION
Fix for dynamic version has been introduced in uv 0.5.19 so require uv >=0.5.19.

Signed-off-by: Patrick ZAJDA <patrick@zajda.fr>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated project configuration to specify minimum required version of `uv` tool

<!-- end of auto-generated comment: release notes by coderabbit.ai -->