### PR TITLE
Replace extra-dependencies by dependency groups

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -41,7 +41,7 @@ jobs:
           cache-suffix: lint
 
       - name: 📦 Install dependencies
-        run: uv sync --frozen --extra lint
+        run: uv sync --frozen --group lint
 
       - name: Pre-commit cache
         uses: actions/cache@v4.2.0
@@ -76,7 +76,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: 📦 Install dependencies
-        run: uv sync --frozen --extra test
+        run: uv sync --frozen --group test
 
       - name: 🏃 Run tests
         run: uv run pytest tests
@@ -152,7 +152,7 @@ jobs:
         id: python
 
       - name: 📦 Install dependencies
-        run: uv sync --frozen --extra doc
+        run: uv sync --frozen --group doc
 
       - name: Build documentation using sphinx
         run: uv run make -C docs html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         id: python
 
       - name: 📦 Install dependencies
-        run: uv sync --frozen --extra doc --extra ci
+        run: uv sync --frozen --group ci
 
       - name: Get version
         id: get-version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "aiohttp>=3.8.0,<4.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 doc = [
     "Sphinx==8.1.3",
     "furo==2024.8.6",
@@ -51,6 +51,7 @@ test = [
     "pytest-cov==6.0.0",
 ]
 ci = [
+    {include-group = "doc"},
     "hatch-vcs==0.4.0"
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -841,9 +841,11 @@ dependencies = [
     { name = "aiohttp" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 ci = [
+    { name = "furo" },
     { name = "hatch-vcs" },
+    { name = "sphinx" },
 ]
 doc = [
     { name = "furo" },
@@ -862,18 +864,28 @@ test = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "aiohttp", specifier = ">=3.8.0,<4.0" },
-    { name = "aresponses", marker = "extra == 'test'", specifier = "==3.0.0" },
-    { name = "coverage", marker = "extra == 'test'", specifier = "==7.6.10" },
-    { name = "furo", marker = "extra == 'doc'", specifier = "==2024.8.6" },
-    { name = "hatch-vcs", marker = "extra == 'ci'", specifier = "==0.4.0" },
-    { name = "mypy", marker = "extra == 'lint'", specifier = "==1.14.1" },
-    { name = "pre-commit", marker = "extra == 'lint'", specifier = "==4.0.1" },
-    { name = "pytest", marker = "extra == 'test'", specifier = "==8.3.4" },
-    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = "==0.25.2" },
-    { name = "pytest-cov", marker = "extra == 'test'", specifier = "==6.0.0" },
-    { name = "sphinx", marker = "extra == 'doc'", specifier = "==8.1.3" },
+requires-dist = [{ name = "aiohttp", specifier = ">=3.8.0,<4.0" }]
+
+[package.metadata.requires-dev]
+ci = [
+    { name = "furo", specifier = "==2024.8.6" },
+    { name = "hatch-vcs", specifier = "==0.4.0" },
+    { name = "sphinx", specifier = "==8.1.3" },
+]
+doc = [
+    { name = "furo", specifier = "==2024.8.6" },
+    { name = "sphinx", specifier = "==8.1.3" },
+]
+lint = [
+    { name = "mypy", specifier = "==1.14.1" },
+    { name = "pre-commit", specifier = "==4.0.1" },
+]
+test = [
+    { name = "aresponses", specifier = "==3.0.0" },
+    { name = "coverage", specifier = "==7.6.10" },
+    { name = "pytest", specifier = "==8.3.4" },
+    { name = "pytest-asyncio", specifier = "==0.25.2" },
+    { name = "pytest-cov", specifier = "==6.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
- **Use PEP 735 groups instead of extra-dependencies in pyproject.toml**
- **Update workflows to use dependencies groups**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated dependency management configuration in GitHub Actions workflows.
	- Restructured dependency groups in project configuration.
	- Modified dependency installation commands to use new grouping approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->