### PR TITLE
Pin GH actions to commit sha instead of tags

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,10 @@
     {
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
     }
   ],
   "timezone": "Europe/Paris"


### PR DESCRIPTION
This should solve a lot of CodeQL alerts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Renovate configuration to pin digests for GitHub Actions used in workflows, improving security and reliability of automated dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->