### PR TITLE
Ignore line length in yamllint pre-commit hook

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,5 +1,6 @@
 ---
 # Taken from pyhaversion
+# yamllint disable rule:line-length
 name: Actions
 
 on:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,3 +1,5 @@
+---
+# yamllint disable rule:line-length
 name: Auto-merge pre-commit-ci PRs
 
 on:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:line-length
 name: "Dependency review"
 on: [pull_request]
 


### PR DESCRIPTION
This will allow commit sha pining for GitHub actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration files to adjust linting settings, ensuring line length rules are ignored for improved maintainability. No changes were made to workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->