### PR TITLE
refactor: derive custom exception from Exception

### DIFF
--- a/src/pysmsboxnet/exceptions.py
+++ b/src/pysmsboxnet/exceptions.py
@@ -1,7 +1,7 @@
 """Exceptions for SMSBox API."""
 
 
-class SMSBoxException(Exception):
+class SMSBoxException(Exception):  # noqa: N818
     """Base exception for SMSBox API."""
 
     def __init__(self, message: str = "Unknown API error"):

--- a/src/pysmsboxnet/exceptions.py
+++ b/src/pysmsboxnet/exceptions.py
@@ -1,7 +1,7 @@
 """Exceptions for SMSBox API."""
 
 
-class SMSBoxException(BaseException):
+class SMSBoxException(Exception):
     """Base exception for SMSBox API."""
 
     def __init__(self, message: str = "Unknown API error"):


### PR DESCRIPTION
## Summary
- make SMSBoxException inherit from Exception

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68acd1b492808324a45731aca962d933

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the library's base error type to a standard Exception so errors are more consistently caught by typical try/except handlers.
  * Improves compatibility with frameworks, middleware, and logging tools that expect standard exceptions, reducing unexpected crashes while preserving existing error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->