### PR TITLE
fix: inherit SMSBoxException from Exception

### DIFF
--- a/src/pysmsboxnet/exceptions.py
+++ b/src/pysmsboxnet/exceptions.py
@@ -1,7 +1,7 @@
 """Exceptions for SMSBox API."""
 
 
-class SMSBoxException(Exception):
+class SMSBoxException(BaseException):
     """Base exception for SMSBox API."""
 
     def __init__(self, message: str = "Unknown API error"):

--- a/src/pysmsboxnet/exceptions.py
+++ b/src/pysmsboxnet/exceptions.py
@@ -1,7 +1,7 @@
 """Exceptions for SMSBox API."""
 
 
-class SMSBoxException(BaseException):
+class SMSBoxException(Exception):
     """Base exception for SMSBox API."""
 
     def __init__(self, message: str = "Unknown API error"):
@@ -55,7 +55,7 @@ class InternalErrorException(SMSBoxException):
 
 
 class HTTPException(SMSBoxException):
-    """Exception when API returns ERROR 03."""
+    """Exception raised when the HTTP status is not successful."""
 
     def __init__(self, error_code: int):
         """Initialize HTTP error Exception."""


### PR DESCRIPTION
## Summary
- ensure custom SMSBox exceptions inherit from `Exception`
- clarify HTTPException docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68accff89aa0832493f46757b5485ea5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the HTTP error description to indicate it’s raised when an HTTP response status is not successful. This is a documentation-only change with no functional effect, no signature or API changes, and no impact on existing behavior. Estimated review effort: low.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->