### PR TITLE
Fix typo in wrong recipient error message

### DIFF
--- a/src/pysmsboxnet/exceptions.py
+++ b/src/pysmsboxnet/exceptions.py
@@ -43,7 +43,7 @@ class WrongRecipientException(SMSBoxException):
 
     def __init__(self) -> None:
         """Initialize when recipient is bad, no message to specify."""
-        super().__init__("Wrong recipient(s), not valid or missformated")
+        super().__init__("Wrong recipient(s), not valid or misformatted")
 
 
 class InternalErrorException(SMSBoxException):


### PR DESCRIPTION
## Summary
- correct "misformatted" typo in WrongRecipientException message

## Testing
All is OK after settings modifications.
------
https://chatgpt.com/codex/tasks/task_e_68acd1a1afb883249a7063261cb7fe89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Corrected a typo in an error message for WrongRecipientException (“missformated” → “misformatted”), improving clarity and professionalism of error output.
  - No changes to behavior or control flow.

- Compatibility
  - No changes to public APIs or exported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->