### PR TITLE
chore: hide CodeRabbit review status comment

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,6 +13,7 @@ reviews:
     github-checks:
       timeout_ms: 120000
   high_level_summary: true
+  review_status: false
   path_filters:
     - src/**
     - tests/**


### PR DESCRIPTION
Set reviews.review_status: false in .coderabbit.yaml to suppress the automatic 'Review skipped' status comment when auto reviews are disabled.\n\nNo functional changes; formatting and hooks pass. Auto-merge disabled.