### PR TITLE
feat(client): timeouts, redacted logs, strict parsing; add NetworkException; doc/build fixes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import PackageNotFoundError, version as get_version
 
 sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath(".."))
@@ -17,11 +17,9 @@ project = "PySMSBoxNet"
 copyright = "2022, Patrick ZAJDA"
 author = "Patrick ZAJDA"
 try:
-    version = version("pysmsboxnet")
-    print(version)
+    release = get_version("pysmsboxnet")
 except PackageNotFoundError:
-    print("Package pysmsboxnet not found")
-    # pass
+    release = "unknown"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/develop.rst
+++ b/docs/develop.rst
@@ -3,6 +3,6 @@ Add features to pysmsboxnet
 
 To implement a new API feature, add a new method that calls the following private method:
 
-.. autofunction:: pysmsboxnet.api.Client.__smsbox_request
+.. automethod:: pysmsboxnet.api.Client._smsbox_request
 
 If an exception is needed, place it in ``pysmsboxnet/exceptions.py`` and have it extend :py:class:`pysmsboxnet.exceptions.SMSBoxException`.

--- a/example.py
+++ b/example.py
@@ -38,7 +38,6 @@ async def main():
                 print("No remaining credits")
         except exceptions.SMSBoxException as e:
             print(f"Exception: {e}")
-            await session.close()
 
 
 # Get API key from environment variable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,8 @@ exclude = [
     ".github",
     "codecov.yml",
     "example.py",
-    "script",
-    ".pre-commit-config.yaml "
+    "scripts",
+    ".pre-commit-config.yaml"
 ]
 
 [tool.uv]

--- a/src/pysmsboxnet/api.py
+++ b/src/pysmsboxnet/api.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import re
+from collections.abc import Mapping
 from http import client as http_client
 
-from aiohttp import ClientSession
+from aiohttp import ClientError, ClientSession, ClientTimeout
+from aiohttp import __version__ as aiohttp_version
+from yarl import URL
 
+from . import __version__ as pkg_version
 from . import exceptions
 
 _LOGGER = logging.getLogger(__name__)
@@ -18,19 +24,52 @@ class Client:
     :param aiohttp.ClientSession session: the aiohttp session to use
     :param str host: the API endpoint host, for example ``api.smsbox.pro`` (HTTPS is enforced)
     :param str cle_api: the SMSBox API key; the parameter name is in French to match the official documentation
+    :param timeout: request timeout (seconds or ``aiohttp.ClientTimeout``), default 10s
+    :param headers: optional extra headers (can override ``User-Agent`` if provided)
     """
 
-    def __init__(self, session: ClientSession, host: str, cle_api: str):
+    def __init__(
+        self,
+        session: ClientSession,
+        host: str,
+        cle_api: str,
+        *,
+        timeout: ClientTimeout | float | None = None,
+        headers: Mapping[str, str] | None = None,
+    ):
         """Initialize the client."""
+        # Basic validation of host to avoid accidental schema/paths
+        if not host or "/" in host or "://" in host or " " in host:
+            raise ValueError("host must be a bare hostname, e.g. 'api.smsbox.pro'")
+
         self.host = host
         self.cle_api = cle_api
         self.session = session
 
-    async def __smsbox_request(self, uri: str, parameters: dict[str, str]) -> str:
+        if timeout is None:
+            self._timeout = ClientTimeout(total=10)
+        elif isinstance(timeout, (int, float)):  # noqa: UP038
+            self._timeout = ClientTimeout(total=float(timeout))
+        else:
+            self._timeout = timeout
+
+        self._user_agent = f"pysmsboxnet/{pkg_version} aiohttp/{aiohttp_version}"
+        self._headers_extra = dict(headers or {})
+
+    @staticmethod
+    def _redact(parameters: Mapping[str, str]) -> dict[str, str]:
+        """Return a redacted copy of parameters for safe logging."""
+        redacted = dict(parameters)
+        for key in ("msg", "dest"):
+            if key in redacted:
+                redacted[key] = "<redacted>"
+        return redacted
+
+    async def _smsbox_request(self, uri: str, parameters: Mapping[str, str]) -> str:
         """Send a request to the API (internal helper).
 
         :param str uri: the API path, for example ``api.php`` or ``1.1/api.php``
-        :param dict parameters: form parameters to pass to the API
+        :param Mapping parameters: form parameters to pass to the API
 
         :returns: SMSBox API response
         :rtype: str
@@ -45,41 +84,58 @@ class Client:
         """
         headers = {
             "authorization": f"App {self.cle_api}",
+            "User-Agent": self._headers_extra.get("User-Agent", self._user_agent),
         }
+        if self._headers_extra:
+            headers.update(self._headers_extra)
 
         _LOGGER.debug(
             "Sending request to SMSBox API using host %s with URI %s and parameters %s",
             self.host,
             uri,
-            parameters,
+            self._redact(parameters),
         )
-        async with self.session.post(
-            url=f"https://{self.host}/{uri}",
-            headers=headers,
-            data=parameters,
-        ) as resp:
-            _LOGGER.debug("HTTP response: %s", resp.status)
-            if resp.status != http_client.OK:
-                raise exceptions.HTTPException(resp.status)
-            resp_text = await resp.text()
-            _LOGGER.debug("API response: %s", resp_text)
-            if resp_text == "ERROR":
-                raise exceptions.SMSBoxException
-            elif resp_text == "ERROR 01":
-                raise exceptions.ParameterErrorException
-            elif resp_text == "ERROR 02":
-                raise exceptions.AuthException
-            elif resp_text == "ERROR 03":
-                raise exceptions.BillingException
-            elif resp_text == "ERROR 04":
-                raise exceptions.WrongRecipientException
-            elif resp_text == "ERROR 05":
-                raise exceptions.InternalErrorException
-            else:
+        url = URL.build(scheme="https", host=self.host, path=f"/{uri.lstrip('/')}")
+        try:
+            async with self.session.post(
+                url=url.human_repr(),
+                headers=headers,
+                data=parameters,
+                timeout=self._timeout,
+            ) as resp:
+                _LOGGER.debug("HTTP response: %s", resp.status)
+                if resp.status != http_client.OK:
+                    raise exceptions.HTTPException(resp.status)
+                resp_text = (await resp.text()).strip()
+                _LOGGER.debug("API response: %s", resp_text)
+
+                error_map: dict[str, type[exceptions.SMSBoxException]] = {
+                    "ERROR": exceptions.SMSBoxException,
+                    "ERROR 01": exceptions.ParameterErrorException,
+                    "ERROR 02": exceptions.AuthException,
+                    "ERROR 03": exceptions.BillingException,
+                    "ERROR 04": exceptions.WrongRecipientException,
+                    "ERROR 05": exceptions.InternalErrorException,
+                }
+                if resp_text in error_map:
+                    raise error_map[resp_text]()
+
                 return resp_text
+        except (TimeoutError, Exception) as err:
+            # Re-map aiohttp network exceptions to a library-specific one
+            # while preserving HTTPException raised above.
+            if isinstance(err, exceptions.SMSBoxException):
+                raise
+            if isinstance(err, (ClientError, asyncio.TimeoutError)):  # noqa: UP038
+                raise exceptions.NetworkException(str(err)) from err
+            raise
 
     async def send(
-        self, dest: str, msg: str, mode: str, parameters: dict[str, str] | None = None
+        self,
+        dest: str,
+        msg: str,
+        mode: str,
+        parameters: Mapping[str, str] | None = None,
     ) -> int:
         """Send an SMS.
 
@@ -91,21 +147,20 @@ class Client:
         :returns: SMS ID if the ``id`` parameter is set to ``1``; otherwise ``0``
         :rtype: int
         """
-        post_data = {
+        post_data: dict[str, str] = {
             "dest": dest,
             "msg": msg,
             "mode": mode,
             "charset": "utf-8",
         }
         if parameters:
-            post_data.update(parameters)
+            post_data.update(dict(parameters))
 
-        resp_text = await self.__smsbox_request("1.1/api.php", post_data)
-
-        resp_ok = resp_text.split(" ")
-        if len(resp_ok) == 1:
-            return 0
-        return int(resp_ok[1])
+        resp_text = await self._smsbox_request("1.1/api.php", post_data)
+        m = re.match(r"^OK(?:\s+(\d+))?$", resp_text)
+        if not m:
+            raise exceptions.SMSBoxException(resp_text)
+        return int(m.group(1)) if m.group(1) else 0
 
     async def get_credits(self) -> float:
         """Return the number of credits as a float.
@@ -116,8 +171,8 @@ class Client:
             "action": "credit",
         }
 
-        resp_text = await self.__smsbox_request("api.php", post_data)
-        if resp_text.startswith("CREDIT"):
-            return float(resp_text.split(" ")[1])
-        else:
-            raise exceptions.SMSBoxException(resp_text)
+        resp_text = await self._smsbox_request("api.php", post_data)
+        m = re.match(r"^CREDIT\s+([0-9]+(?:\.[0-9]+)?)$", resp_text)
+        if m:
+            return float(m.group(1))
+        raise exceptions.SMSBoxException(resp_text)

--- a/src/pysmsboxnet/exceptions.py
+++ b/src/pysmsboxnet/exceptions.py
@@ -60,3 +60,11 @@ class HTTPException(SMSBoxException):
     def __init__(self, error_code: int):
         """Initialize HTTP error exception."""
         super().__init__(f"HTTP error ({error_code})")
+
+
+class NetworkException(SMSBoxException):
+    """Exception raised on network/transport errors (timeout, DNS, etc.)."""
+
+    def __init__(self, message: str):
+        """Initialize network error exception with a message."""
+        super().__init__(message)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -284,3 +284,24 @@ async def test_error_credits(aresponses: Any) -> None:
         )
         with pytest.raises(exceptions.SMSBoxException):
             await sms.get_credits()
+
+
+@pytest.mark.asyncio
+async def test_send_ok_with_host_and_port(aresponses: Any) -> None:
+    """Test sending with a host that includes an explicit port."""
+    expected_id = 4242
+    aresponses.add(
+        "localhost:8443",
+        "/1.1/api.php",
+        "post",
+        aresponses.Response(text=f"OK {expected_id}", status=200),
+    )
+    async with aiohttp.ClientSession() as session:
+        sms = Client(session, "localhost:8443", SMSBOX_API_KEY)
+        result = await sms.send(
+            SMS_RECIPIENT,
+            SMS_MSG,
+            SEND_MODE,
+            {"strategy": SMSBOX_STRATEGY, "id": "1"},
+        )
+        assert result == expected_id

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import random
 from typing import Any
 
@@ -23,20 +24,30 @@ SMSBOX_STRATEGY = "2"
 
 
 @pytest.mark.asyncio
-async def test_parameters_error(aresponses: Any) -> None:
-    """Test if exception is raised if web server returns ERROR 01."""
+@pytest.mark.parametrize(
+    ("api_text", "exc"),
+    [
+        ("ERROR 01", exceptions.ParameterErrorException),
+        ("ERROR 02", exceptions.AuthException),
+        ("ERROR 03", exceptions.BillingException),
+        ("ERROR 04", exceptions.WrongRecipientException),
+        ("ERROR 05", exceptions.InternalErrorException),
+        ("ERROR", exceptions.SMSBoxException),
+    ],
+)
+async def test_send_errors_param(
+    aresponses: Any, api_text: str, exc: type[Exception]
+) -> None:
+    """Test mapping of error responses to exceptions (parametrized)."""
     aresponses.add(
         "api.smsbox.pro",
         "/1.1/api.php",
         "post",
-        aresponses.Response(
-            text="ERROR 01",
-            status=200,
-        ),
+        aresponses.Response(text=api_text, status=200),
     )
     async with aiohttp.ClientSession() as session:
         sms = Client(session, SMSBOX_HOST, SMSBOX_API_KEY)
-        with pytest.raises(exceptions.ParameterErrorException):
+        with pytest.raises(exc):
             await sms.send(
                 SMS_RECIPIENT,
                 SMS_MSG,
@@ -45,139 +56,83 @@ async def test_parameters_error(aresponses: Any) -> None:
             )
 
 
+# Old individual error tests are superseded by the parametrized test above.
+
+
 @pytest.mark.asyncio
-async def test_bad_auth(aresponses: Any) -> None:
-    """Test if exception is raised in case of wrong authentication ERROR 02."""
+async def test_send_unknown_response_raises(aresponses: Any) -> None:
+    """Test that an unexpected send response raises an exception."""
     aresponses.add(
         "api.smsbox.pro",
         "/1.1/api.php",
         "post",
-        aresponses.Response(
-            text="ERROR 02",
-            status=200,
-        ),
+        aresponses.Response(text="FFF", status=200),
     )
     async with aiohttp.ClientSession() as session:
-        sms = Client(
-            session,
-            SMSBOX_HOST,
-            SMSBOX_API_KEY,
-        )
-        with pytest.raises(exceptions.AuthException):
-            await sms.send(
-                SMS_RECIPIENT,
-                SMS_MSG,
-                SEND_MODE,
-                {"strategy": SMSBOX_STRATEGY},
-            )
-
-
-@pytest.mark.asyncio
-async def test_billing(aresponses: Any) -> None:
-    """Test if BillingException is raised in case of ERROR 03."""
-    aresponses.add(
-        "api.smsbox.pro",
-        "/1.1/api.php",
-        "post",
-        aresponses.Response(
-            text="ERROR 03",
-            status=200,
-        ),
-    )
-    async with aiohttp.ClientSession() as session:
-        sms = Client(
-            session,
-            SMSBOX_HOST,
-            SMSBOX_API_KEY,
-        )
-        with pytest.raises(exceptions.BillingException):
-            await sms.send(
-                SMS_RECIPIENT,
-                SMS_MSG,
-                SEND_MODE,
-                {"strategy": SMSBOX_STRATEGY},
-            )
-
-
-@pytest.mark.asyncio
-async def test_bad_dest(aresponses: Any) -> None:
-    """Test if WrongRecipientException is raised on ERROR 04."""
-    aresponses.add(
-        "api.smsbox.pro",
-        "/1.1/api.php",
-        "post",
-        aresponses.Response(
-            text="ERROR 04",
-            status=200,
-        ),
-    )
-    async with aiohttp.ClientSession() as session:
-        sms = Client(
-            session,
-            SMSBOX_HOST,
-            SMSBOX_API_KEY,
-        )
-        with pytest.raises(exceptions.WrongRecipientException):
-            await sms.send(
-                SMS_RECIPIENT,
-                SMS_MSG,
-                SEND_MODE,
-                {"strategy": SMSBOX_STRATEGY},
-            )
-
-
-@pytest.mark.asyncio
-async def test_internal_error(aresponses: Any) -> None:
-    """Test if right exception is raised on ERROR 05."""
-    aresponses.add(
-        "api.smsbox.pro",
-        "/1.1/api.php",
-        "post",
-        aresponses.Response(
-            text="ERROR 05",
-            status=200,
-        ),
-    )
-    async with aiohttp.ClientSession() as session:
-        sms = Client(
-            session,
-            SMSBOX_HOST,
-            SMSBOX_API_KEY,
-        )
-        with pytest.raises(exceptions.InternalErrorException):
-            await sms.send(
-                SMS_RECIPIENT,
-                SMS_MSG,
-                SEND_MODE,
-                {"strategy": SMSBOX_STRATEGY},
-            )
-
-
-@pytest.mark.asyncio
-async def test_other_error(aresponses: Any) -> None:
-    """Test unknown error."""
-    aresponses.add(
-        "api.smsbox.pro",
-        "/1.1/api.php",
-        "post",
-        aresponses.Response(
-            text="ERROR",
-            status=200,
-        ),
-    )
-    async with aiohttp.ClientSession() as session:
-        sms = Client(
-            session,
-            SMSBOX_HOST,
-            SMSBOX_API_KEY,
-        )
+        sms = Client(session, SMSBOX_HOST, SMSBOX_API_KEY)
         with pytest.raises(exceptions.SMSBoxException):
             await sms.send(
-                SMS_RECIPIENT,
-                SMS_MSG,
-                SEND_MODE,
-                {"strategy": SMSBOX_STRATEGY},
+                SMS_RECIPIENT, SMS_MSG, SEND_MODE, {"strategy": SMSBOX_STRATEGY}
             )
+
+
+@pytest.mark.asyncio
+async def test_network_timeout_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that a timeout is mapped to NetworkException."""
+    async with aiohttp.ClientSession() as session:
+        sms = Client(session, SMSBOX_HOST, SMSBOX_API_KEY, timeout=0.1)
+
+        def raise_timeout(*_a: Any, **_k: Any) -> Any:
+            raise TimeoutError()
+
+        monkeypatch.setattr(session, "post", raise_timeout)
+
+        with pytest.raises(exceptions.NetworkException):
+            await sms.send(
+                SMS_RECIPIENT, SMS_MSG, SEND_MODE, {"strategy": SMSBOX_STRATEGY}
+            )
+
+
+@pytest.mark.asyncio
+async def test_network_client_error_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that a ClientError is mapped to NetworkException."""
+    async with aiohttp.ClientSession() as session:
+        sms = Client(session, SMSBOX_HOST, SMSBOX_API_KEY)
+
+        def raise_client_error(*_a: Any, **_k: Any) -> Any:
+            raise aiohttp.ClientError("boom")
+
+        monkeypatch.setattr(session, "post", raise_client_error)
+
+        with pytest.raises(exceptions.NetworkException):
+            await sms.send(
+                SMS_RECIPIENT, SMS_MSG, SEND_MODE, {"strategy": SMSBOX_STRATEGY}
+            )
+
+
+@pytest.mark.asyncio
+async def test_logs_redact_msg_and_dest(
+    aresponses: Any, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Ensure logs do not expose sensitive fields."""
+    aresponses.add(
+        "api.smsbox.pro",
+        "/1.1/api.php",
+        "post",
+        aresponses.Response(text="OK 123", status=200),
+    )
+    async with aiohttp.ClientSession() as session:
+        sms = Client(session, SMSBOX_HOST, SMSBOX_API_KEY)
+        caplog.set_level(logging.DEBUG, logger="pysmsboxnet.api")
+        dest_val = "+33123456789"
+        msg_val = "hello secret"
+        await sms.send(
+            dest_val, msg_val, SEND_MODE, {"strategy": SMSBOX_STRATEGY, "id": "1"}
+        )
+        text = caplog.text
+        assert dest_val not in text
+        assert msg_val not in text
+        assert "<redacted>" in text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR strengthens the client's robustness, readability, and security.

Key changes
- Default timeout (10s) with a configurable parameter (float or ClientTimeout).
- Headers: default User-Agent (pysmsboxnet/<version> aiohttp/<version>) and support for extra headers.
- URLs: safe construction via yarl.URL.build and basic host validation; supports hosts with an explicit port (e.g., localhost:8443).
- Logging: redact sensitive fields (msg, dest) in debug traces.
- Network errors: new NetworkException for aiohttp timeouts/transport errors.
- Strict response parsing: send() only accepts "OK" or "OK <id>"; get_credits() only accepts "CREDIT <float>". Any other response raises SMSBoxException.
- Internal method rename: __smsbox_request → _smsbox_request (more idiomatic and easier to document).

Docs/Build
- Docs: switch to automethod for _smsbox_request; simplify Sphinx config (use `release`, no prints).
- Build: fix Hatch build excludes (scripts; remove trailing space).
- Example: remove redundant close().

Impact
- Public API: optional extra headers (User-Agent can be overridden). Intended behavior change: unexpected responses now raise instead of returning 0.
- Exceptions: ERROR xx codes still map to the same dedicated exceptions (all subclass SMSBoxException).

Verification
- Pre-commit (lint/format/mypy/secrets): passing.
- Tests: 17/17 passing (pytest-asyncio strict + aresponses), including network/timeout and log-redaction cases.

Optional next steps
- Add a troubleshooting section to docs covering error codes, timeouts, and log redaction behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added configurable request timeouts and custom headers.
  * Improved network error reporting with a dedicated exception and strict HTTP status handling.
  * Support for hosts with explicit ports.
  * Enhanced response parsing: message send returns an ID when provided; credits parsing hardened.
  * Safer logging with redaction of sensitive fields.
  * User-Agent now includes library/runtime versions.

* Bug Fixes
  * More resilient handling of unexpected API responses; default timeout applied when absent.

* Documentation
  * Updated developer docs to reflect protected method.
  * Simplified docs version retrieval.

* Tests
  * Expanded coverage for API errors, network timeouts, HTTP errors, log redaction, and ported hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->