### PR TITLE
ci: simplify test matrix

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -59,13 +59,12 @@ jobs:
         run: uv run pre-commit run --show-diff-on-failure --all-files
 
   test:
-    name: Test with Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    name: Test with Python ${{ matrix.python-version }}
     needs: lint
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.11, 3.12, 3.13]
-        os: [ubuntu, windows, macos]
     steps:
       - name: 📥 Checkout the repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -74,7 +73,7 @@ jobs:
         uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
           enable-cache: true
-          cache-suffix: test-${{ matrix.python-version }}-${{ matrix.os }}
+          cache-suffix: test-${{ matrix.python-version }}
 
       - name: install Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -83,30 +82,23 @@ jobs:
         run: uv sync --frozen --group test
 
       - name: 🏃 Run tests
-        run: uv run pytest tests
-
-      - name: Run code coverage
         run: uv run pytest --cov=./src --cov-report=xml tests
 
       - name: upload to codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
 
   test_install:
-    name: "Test install with Python ${{matrix.python-version}} ${{matrix.os}}"
+    name: Test install with Python 3.13
     needs: test
-    runs-on: ${{ matrix.os }}-latest
-    strategy:
-      matrix:
-        python-version: [3.11, 3.12, 3.13]
-        os: [ubuntu, windows, macos]
+    runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout the repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: 🛠️ Set up Python ${{ matrix.python-version }}
+      - name: 🛠️ Set up Python 3.13
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.13"
           check-latest: true
 
       - name: Install using pip


### PR DESCRIPTION
## Summary

- run the test suite on Ubuntu for each supported Python version
- run the package installation and example check once on Ubuntu with Python 3.13
- combine the regular and coverage pytest invocations into a single run

## Rationale

The library contains no platform-specific code: HTTP behavior is implemented through aiohttp and exercised with mocked responses. Running the same suite and installation check across Linux, Windows, and macOS therefore added substantial CI work without meaningful project-specific coverage.

The revised workflow retains coverage of every supported Python version while reducing the test and installation matrix from 18 jobs to 4.

## Validation

- uv run pre-commit run --all-files
- uv run pytest --cov=./src --cov-report=term-missing tests (17 passed, 94% coverage)
- commit-time pre-commit hooks